### PR TITLE
Remove unnecessary dependency on flutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.1.7]
+- Remove unnecessary dependency on flutter
+
 ## [1.1.6]
 
 - Web platform support. (see [stackoverflow](https://stackoverflow.com/questions/65630743/how-to-solve-flutter-web-api-cors-error-only-with-dart-code) for CORSB problems needing attention)

--- a/lib/src/webdav_dio.dart
+++ b/lib/src/webdav_dio.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
-import 'package:flutter/foundation.dart' show kIsWeb;
 
 import 'adapter/adapter_stub.dart'
     if (dart.library.io) 'adapter/adapter_mobile.dart'
@@ -37,7 +36,7 @@ class WdDio with DioMixin implements Dio {
     // 状态码错误视为成功
     this.options.validateStatus = (status) => true;
 
-    httpClientAdapter = kIsWeb ? getAdapter() : getAdapter();
+    httpClientAdapter = getAdapter();
 
     // 拦截器
     if (interceptorList != null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: webdav_client
 description: A dart WebDAV client library,  support Basic/Digest authentication、read、make、delete、rename、copy、download、upload、cancel request 
 
-version: 1.1.6
+version: 1.1.7
 homepage: https://github.com/flymzero/webdav_client
 
 environment:
@@ -11,9 +11,6 @@ dependencies:
   dio: ^4.0.4
   xml: ^5.3.0
   convert: ^3.0.1
-  flutter: 
-    sdk: flutter
-    version: ^0.0.0
 
 dev_dependencies:
   test: '>=1.0.0 <2.0.0'


### PR DESCRIPTION
Depending on flutter makes it impossible to use the library in a pure dart project. Also the `kIsWeb` switch wasn't doing anything at all, because the imports already did the job.