### PR TITLE
Update dependencies to latest and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.1.8]
+- Dependency Update
+ 
 ## [1.1.7]
 - Remove unnecessary dependency on flutter
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -33,11 +33,6 @@ dependencies:
   webdav_client: 
     path: ../
 
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
-
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -47,7 +42,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: webdav_client
 description: A simple WebDAV client that supports some common methods.
 
-version: 1.1.7
+version: 1.1.8
 homepage: https://github.com/flymzero/webdav_client
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  dio: ^4.0.4
-  xml: ^5.3.0
-  convert: ^3.0.1
+  dio: ^4.0.6
+  xml: ^6.1.0
+  convert: ^3.0.2
 
 dev_dependencies:
   test: '>=1.0.0 <2.0.0'


### PR DESCRIPTION
Outdated dependencies are updated due to version solving incompatibilities with Flutter 3.0.x

### Changes:
- Bumped version to **1.1.8**
- Updated dependencies to latest
  - There were no breaking changes according to their changelogs published on pub.dev
    - [dio](https://pub.dev/packages/dio/changelog)
    - [xml](https://pub.dev/packages/xml/changelog)
    - [convert](https://pub.dev/packages/convert/changelog)

### Example App Changes:
- Updated [flutter_lints](https://pub.dev/packages/flutter_lints/changelog) to latest
- Removed boilerplate [cupertino_icons](https://pub.dev/packages/cupertino_icons) dependency as it was not being used
- Updated Kotlin & gradle dependencies as example app was not compiling
  - Kotlin 1.3.50 -> 1.7.10
    - Minimum supported Gradle version: 6.7.1
  - Android Gradle plugin version 4.1.0 -> 4.2.0
