### PR TITLE
Update dependencies to latest and bump version

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,10 +24,10 @@ class MyHomePage extends StatefulWidget {
   const MyHomePage({Key? key}) : super(key: key);
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  MyHomePageState createState() => MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
+class MyHomePageState extends State<MyHomePage> {
   // webdav
   late webdav.Client client;
 

--- a/lib/src/adapter/adapter_mobile.dart
+++ b/lib/src/adapter/adapter_mobile.dart
@@ -1,4 +1,4 @@
-import 'package:dio/adapter.dart';
 import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
 
-HttpClientAdapter getAdapter() => DefaultHttpClientAdapter();
+HttpClientAdapter getAdapter() => IOHttpClientAdapter();

--- a/lib/src/adapter/adapter_web.dart
+++ b/lib/src/adapter/adapter_web.dart
@@ -1,4 +1,4 @@
-import 'package:dio/adapter_browser.dart';
+import 'package:dio/browser.dart';
 import 'package:dio/dio.dart';
 
 HttpClientAdapter getAdapter() => BrowserHttpClientAdapter();

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -36,13 +36,16 @@ class Client {
       this.c.options.headers = headers;
 
   /// Set the connection server timeout time in milliseconds.
-  void setConnectTimeout(int timout) => this.c.options.connectTimeout = timout;
+  void setConnectTimeout(int timeout) =>
+      this.c.options.connectTimeout = Duration(milliseconds: timeout);
 
   /// Set send data timeout time in milliseconds.
-  void setSendTimeout(int timout) => this.c.options.sendTimeout = timout;
+  void setSendTimeout(int timeout) =>
+      this.c.options.sendTimeout = Duration(milliseconds: timeout);
 
   /// Set transfer data time in milliseconds.
-  void setReceiveTimeout(int timout) => this.c.options.receiveTimeout = timout;
+  void setReceiveTimeout(int timeout) =>
+      this.c.options.receiveTimeout = Duration(milliseconds: timeout);
 
   /// Test whether the service can connect
   Future<void> ping([CancelToken? cancelToken]) async {

--- a/lib/src/file.dart
+++ b/lib/src/file.dart
@@ -9,7 +9,7 @@ class File {
   DateTime? mTime;
 
   File({
-  this.path,
+    this.path,
     this.isDir,
     this.name,
     this.mimeType,
@@ -17,5 +17,5 @@ class File {
     this.eTag,
     this.cTime,
     this.mTime,
-});
+  });
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -58,7 +58,7 @@ DioError newResponseError(Response resp) {
   return DioError(
       requestOptions: resp.requestOptions,
       response: resp,
-      type: DioErrorType.response,
+      type: DioErrorType.badResponse,
       error: resp.statusMessage);
 }
 
@@ -66,7 +66,7 @@ DioError newResponseError(Response resp) {
 DioError newXmlError(dynamic err) {
   return DioError(
     requestOptions: RequestOptions(path: '/'),
-    type: DioErrorType.other,
+    type: DioErrorType.unknown,
     error: err,
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: webdav_client
 description: A simple WebDAV client that supports some common methods.
 
-version: 1.1.8
+version: 1.1.9
 homepage: https://github.com/flymzero/webdav_client
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  dio: ^4.0.6
-  xml: ^6.1.0
-  convert: ^3.0.2
+  dio: ^5.0.0
+  xml: ^6.2.2
+  convert: ^3.1.1
 
 dev_dependencies:
   test: '>=1.0.0 <2.0.0'


### PR DESCRIPTION
This PR addresses https://github.com/flymzero/webdav_client/issues/22

Outdated dependencies are updated due to version solving incompatibilities with latest Flutter stable(3.7.3).

### Changes:
- Bumped version to **1.1.9** ! _Needs to be uploaded to_ [_pub.dev_](https://pub.dev/packages/webdav_client/admin) !
- Updated dependencies to latest
  -  [dio](https://pub.dev/packages/dio/changelog) had breaking changes as explained [here](https://pub.dev/packages/dio/changelog#500). The ones that applied to this plugin were:
     - Improve DioErrors. There are now more cases in which the inner original stacktrace is supplied.
     - connectTimeout, sendTimeout, and receiveTimeout are now Durations.
     - Null Safety changes
  - There were no breaking changes according to their changelogs published on pub.dev for these plugins:
    - [xml](https://pub.dev/packages/xml/changelog)
    - [convert](https://pub.dev/packages/convert/changelog)

### Example App Changes:
- Resolved "Invalid use of a private type in a public API" linter error