### PR TITLE
Prevent access element of an empty list

### DIFF
--- a/lib/src/xml.dart
+++ b/lib/src/xml.dart
@@ -35,7 +35,8 @@ class WebdavXml {
     // response
     list.forEach((element) {
       // name
-      String href = findElements(element, 'href').single.text;
+      final hrefElements = findElements(element, 'href');
+      String href = hrefElements.isNotEmpty ? hrefElements.single.text : '';
 
       // propstats
       var props = findElements(element, 'propstat');
@@ -45,10 +46,12 @@ class WebdavXml {
         if (findElements(propstat, 'status').single.text.contains('200')) {
           // prop
           for (var prop in findElements(propstat, 'prop')) {
+            final resourceTypeElements = findElements(prop, 'resourcetype');
             // isDir
-            bool isDir = findElements(
-                    findElements(prop, 'resourcetype').single, 'collection')
-                .isNotEmpty;
+            bool isDir = resourceTypeElements.isNotEmpty
+                ? findElements(resourceTypeElements.single, 'collection')
+                    .isNotEmpty
+                : false;
 
             // skip self
             if (skipSelf) {


### PR DESCRIPTION
Had a case where `findElements` returns empty list so `single` would throw "Bad state" exception.
Fixed it i a way to be still compatible with Dart < 3.0.0.