### PR TITLE
Fix: www-authenticate can be a list of elements

### DIFF
--- a/lib/src/webdav_dio.dart
+++ b/lib/src/webdav_dio.dart
@@ -90,8 +90,6 @@ class WdDio with DioMixin implements Dio {
 
     if (resp.statusCode == 401) {
       List<String>? list = resp.headers.map['www-authenticate'];
-//      String? w3AHeader = resp.headers.value('www-authenticate');
-      
 
       if (list != null && list.isNotEmpty) {
         for (final entry in list) {


### PR DESCRIPTION
Here is a fix that allow me to connect to a webdav server with a www-authenticate header containing two entries.

Not tested with a single entry (as the old code).