### PR TITLE
fix: allow 404 status code in OPTIONS request for WebDAV auth

### DIFF
--- a/lib/src/webdav_dio.dart
+++ b/lib/src/webdav_dio.dart
@@ -249,7 +249,7 @@ class WdDio with DioMixin implements Dio {
   }) async {
     // fix auth error
     var pResp = await this.wdOptions(self, path, cancelToken: cancelToken);
-    if (pResp.statusCode != 200) {
+    if ((pResp.statusCode != 200) && (pResp.statusCode != 404)) {
       throw newResponseError(pResp);
     }
 
@@ -291,7 +291,7 @@ class WdDio with DioMixin implements Dio {
   }) async {
     // fix auth error
     var pResp = await this.wdOptions(self, path, cancelToken: cancelToken);
-    if (pResp.statusCode != 200) {
+    if ((pResp.statusCode != 200) && (pResp.statusCode != 404)) {
       throw newResponseError(pResp);
     }
 
@@ -457,7 +457,7 @@ class WdDio with DioMixin implements Dio {
   }) async {
     // fix auth error
     var pResp = await this.wdOptions(self, path, cancelToken: cancelToken);
-    if (pResp.statusCode != 200) {
+    if ((pResp.statusCode != 200) && (pResp.statusCode != 404)) {
       throw newResponseError(pResp);
     }
 
@@ -492,7 +492,7 @@ class WdDio with DioMixin implements Dio {
   }) async {
     // fix auth error
     var pResp = await this.wdOptions(self, path, cancelToken: cancelToken);
-    if (pResp.statusCode != 200) {
+    if ((pResp.statusCode != 200) && (pResp.statusCode != 404)) {
       throw newResponseError(pResp);
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   dio: ^5.1.0
-  xml: ^6.2.2
+  xml: ^7.0.1
   convert: ^3.1.1
 
 dev_dependencies:


### PR DESCRIPTION
This PR improves the authentication check in the `wdOptions` request for WebDAV servers. Previously, the implementation only allowed a `200 OK` response, throwing an error otherwise. However, some WebDAV servers may return `404 Not Found` if the OPTIONS endpoint is not explicitly configured, even though authentication might still be valid.

### Changes Made:
- Updated the authentication logic to also accept `404` as a valid response instead of failing immediately.
- This ensures that the request isn't canceled unnecessarily, allowing authentication to proceed in cases where the OPTIONS endpoint isn't available but the server is still functional.

### Why This is Needed:
- Some WebDAV servers do not properly implement `OPTIONS` for authentication but still allow valid operations.
- Prevents unnecessary authentication failures when encountering a `404` response.
- Improves compatibility with a wider range of WebDAV servers.

### Logs of the Requests:
<details>
<summary>Details</summary>

```plaintext
flutter: 25.02.2025 10:19:20.552 [DEBUG]: webdav-log: *** Request ***
flutter: 25.02.2025 10:19:20.553 [DEBUG]: webdav-log: uri: #####
flutter: 25.02.2025 10:19:20.553 [DEBUG]: webdav-log: method: OPTIONS
flutter: 25.02.2025 10:19:20.553 [DEBUG]: webdav-log: responseType: ResponseType.json
flutter: 25.02.2025 10:19:20.553 [DEBUG]: webdav-log: followRedirects: false
flutter: 25.02.2025 10:19:20.553 [DEBUG]: webdav-log: persistentConnection: true
flutter: 25.02.2025 10:19:20.553 [DEBUG]: webdav-log: connectTimeout: 0:00:10.000000
flutter: 25.02.2025 10:19:20.553 [DEBUG]: webdav-log: sendTimeout: 5:00:00.000000
flutter: 25.02.2025 10:19:20.553 [DEBUG]: webdav-log: receiveTimeout: 5:00:00.000000
flutter: 25.02.2025 10:19:20.554 [DEBUG]: webdav-log: receiveDataWhenStatusError: true
flutter: 25.02.2025 10:19:20.554 [DEBUG]: webdav-log: extra: {}
flutter: 25.02.2025 10:19:20.554 [DEBUG]: webdav-log: headers:
flutter: 25.02.2025 10:19:20.554 [DEBUG]: webdav-log: depth: 0
flutter: 25.02.2025 10:19:20.554 [DEBUG]: webdav-log: authorization: Basic RGFuaWVsQmFkZW46SWx1dmk5MjAxIQ==
flutter: 25.02.2025 10:19:20.554 [DEBUG]: webdav-log:
flutter: 25.02.2025 10:19:20.663 [DEBUG]: webdav-log: *** Response ***
flutter: 25.02.2025 10:19:20.663 [DEBUG]: webdav-log: uri: #####
flutter: 25.02.2025 10:19:20.664 [DEBUG]: webdav-log: statusCode: 404
flutter: 25.02.2025 10:19:20.664 [DEBUG]: webdav-log: headers:
flutter: 25.02.2025 10:19:20.664 [DEBUG]: webdav-log: connection: keep-alive
flutter: 25.02.2025 10:19:20.664 [DEBUG]: webdav-log: x-uets: webapp-57dbc454c6-bkc92
flutter: 25.02.2025 10:19:20.664 [DEBUG]: webdav-log: date: Tue, 25 Feb 2025 09:19:20 GMT
flutter: 25.02.2025 10:19:20.665 [DEBUG]: webdav-log: transfer-encoding: chunked
flutter: 25.02.2025 10:19:20.665 [DEBUG]: webdav-log: content-encoding: gzip
flutter: 25.02.2025 10:19:20.665 [DEBUG]: webdav-log: vary: Accept-Encoding
flutter: 25.02.2025 10:19:20.665 [DEBUG]: webdav-log: strict-transport-security: max-age=15768000
flutter: 25.02.2025 10:19:20.665 [DEBUG]: webdav-log: p3p: CP="ALL ADM DEV PSAi COM OUR OTRo STP IND ONL"
flutter: 25.02.2025 10:19:20.665 [DEBUG]: webdav-log: content-type: text/html; charset=utf-8
flutter: 25.02.2025 10:19:20.666 [DEBUG]: webdav-log: Response Text:
flutter: 25.02.2025 10:19:20.666 [DEBUG]: webdav-log: <html><body><h1>##### Not Found (404)</h1></body></html>
flutter: 25.02.2025 10:19:20.666 [DEBUG]: webdav-log:

flutter: 25.02.2025 10:20:05.510 [DEBUG]: webdav-log: *** Request ***
flutter: 25.02.2025 10:20:05.511 [DEBUG]: webdav-log: uri: #####
flutter: 25.02.2025 10:20:05.511 [DEBUG]: webdav-log: method: PUT
flutter: 25.02.2025 10:20:05.512 [DEBUG]: webdav-log: responseType: ResponseType.json
flutter: 25.02.2025 10:20:05.512 [DEBUG]: webdav-log: followRedirects: false
flutter: 25.02.2025 10:20:05.513 [DEBUG]: webdav-log: persistentConnection: true
flutter: 25.02.2025 10:20:05.513 [DEBUG]: webdav-log: connectTimeout: 0:00:10.000000
flutter: 25.02.2025 10:20:05.513 [DEBUG]: webdav-log: sendTimeout: 5:00:00.000000
flutter: 25.02.2025 10:20:05.514 [DEBUG]: webdav-log: receiveTimeout: 5:00:00.000000
flutter: 25.02.2025 10:20:05.514 [DEBUG]: webdav-log: receiveDataWhenStatusError: true
flutter: 25.02.2025 10:20:05.514 [DEBUG]: webdav-log: extra: {}
flutter: 25.02.2025 10:20:05.514 [DEBUG]: webdav-log: headers:
flutter: 25.02.2025 10:20:05.515 [DEBUG]: webdav-log: content-length: 289280
flutter: 25.02.2025 10:20:05.515 [DEBUG]: webdav-log: authorization: Basic RGFuaWVsQmFkZW46SWx1dmk5MjAxIQ==
flutter: 25.02.2025 10:20:05.516 [DEBUG]: webdav-log:
flutter: 25.02.2025 10:20:06.268 [DEBUG]: webdav-log: *** Response ***
flutter: 25.02.2025 10:20:06.269 [DEBUG]: webdav-log: uri: #####
flutter: 25.02.2025 10:20:06.269 [DEBUG]: webdav-log: statusCode: 201
flutter: 25.02.2025 10:20:06.270 [DEBUG]: webdav-log: headers:
flutter: 25.02.2025 10:20:06.270 [DEBUG]: webdav-log: connection: keep-alive
flutter: 25.02.2025 10:20:06.270 [DEBUG]: webdav-log: date: Tue, 25 Feb 2025 09:20:06 GMT
flutter: 25.02.2025 10:20:06.270 [DEBUG]: webdav-log: transfer-encoding: chunked
flutter: 25.02.2025 10:20:06.271 [DEBUG]: webdav-log: x-uets: webapp-57dbc454c6-bkc92
flutter: 25.02.2025 10:20:06.271 [DEBUG]: webdav-log: accept-ranges: bytes
flutter: 25.02.2025 10:20:06.271 [DEBUG]: webdav-log: strict-transport-security: max-age=15768000
flutter: 25.02.2025 10:20:06.271 [DEBUG]: webdav-log: p3p: CP="ALL ADM DEV PSAi COM OUR OTRo STP IND ONL"
flutter: 25.02.2025 10:20:06.271 [DEBUG]: webdav-log: etag: "1429557176_1013451582"
flutter: 25.02.2025 10:20:06.272 [DEBUG]: webdav-log: Response Text:
```
</details> 
