### PR TITLE
PROFIND请求增加可选参数不要对文件增加尾'/'

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -72,8 +72,10 @@ class Client {
   }
 
   /// Read a single files properties
-  Future<File> readProps(String path, [CancelToken? cancelToken]) async {
-    path = fixSlashes(path);
+  Future<File> readProps(String path,{ bool isFile = false, CancelToken? cancelToken}) async {
+    //如果是文件，不要添加尾 '/', 因为一些服务器可能不支持文件带 尾 '/' 的props请求，例如群晖
+    //If it is a file, do not add a trailing '/', because some servers (such as Synology) may not support PROPFIND requests for files with a trailing '/'.
+    path = isFile ? fixSlashStart(path) : fixSlashes(path);
     var resp = await this
         .c
         .wdPropfind(this, path, true, fileXmlStr, cancelToken: cancelToken);

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -102,11 +102,17 @@ String fixSlash(String s) {
   return s;
 }
 
-// 添加 '/' 前后缀
-String fixSlashes(String s) {
+//添加 '/' 前缀
+String fixSlashStart(String s){
   if (!s.startsWith('/')) {
     s = '/${s}';
   }
+  return s;
+}
+
+// 添加 '/' 前后缀
+String fixSlashes(String s) {
+  s = fixSlashStart(s);
   return fixSlash(s);
 }
 

--- a/lib/src/webdav_dio.dart
+++ b/lib/src/webdav_dio.dart
@@ -469,8 +469,10 @@ class WdDio with DioMixin implements Dio {
       'PUT',
       path,
       data: Stream.fromIterable(data.map((e) => [e])),
-      optionsHandler: (options) =>
-          options.headers?['content-length'] = data.length,
+      optionsHandler: (options) {
+          options.headers?['content-length'] = data.length;
+          options.headers?['content-type'] = "application/octet-stream";
+      },
       onSendProgress: onProgress,
       cancelToken: cancelToken,
     );
@@ -504,7 +506,10 @@ class WdDio with DioMixin implements Dio {
       'PUT',
       path,
       data: data,
-      optionsHandler: (options) => options.headers?['content-length'] = length,
+      optionsHandler: (options) {
+          options.headers?['content-length'] = length;
+          options.headers?['content-type'] = "application/octet-stream";
+      },
       onSendProgress: onProgress,
       cancelToken: cancelToken,
     );


### PR DESCRIPTION
fix: remove trailing slash from file paths in PROPFIND requests.Synology WebDAV requires file paths without trailing slashes to avoid 400 errors.

修复：增加一个参数，让PROPFIND请求如果是文件则不要增加尾 '/'，有些服务器如群晖不支持，会返回400请求